### PR TITLE
Use minified Bootstrap

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,5 +1,6 @@
 graft coldsweat/templates
 
 graft static
+prune static/javascripts/vendor/bootstrap
 prune static/stylesheets
 include static/stylesheets/all.css

--- a/coldsweat/templates/site.html
+++ b/coldsweat/templates/site.html
@@ -35,18 +35,7 @@ head.js(
 // Libraries
 "{{static_url}}/javascripts/vendor/modernizr-min.js",
 "{{static_url}}/javascripts/vendor/jquery-min.js",
-
-// Load bootstrap-transition first so that nice glides/fades 
-// etc for the other bootstrap plugins work
-"{{static_url}}/javascripts/vendor/bootstrap/bootstrap-transition.js",
-"{{static_url}}/javascripts/vendor/bootstrap/bootstrap-tooltip.js",
-
-// Popover has a dependency on tooltip, so make sure and include 
-// bootstrap-tooltip regardless in order for popovers to work
-"{{static_url}}/javascripts/vendor/bootstrap/bootstrap-popover.js",
-"{{static_url}}/javascripts/vendor/bootstrap/bootstrap-modal.js",
-"{{static_url}}/javascripts/vendor/bootstrap/bootstrap-collapse.js",
-"{{static_url}}/javascripts/vendor/bootstrap/bootstrap-dropdown.js",
+"{{static_url}}/javascripts/vendor/bootstrap-min.js",
 
 // Plugins
 "{{static_url}}/javascripts/plugins.js",


### PR DESCRIPTION
I noticed that minified Bootstrap is included in the static directory but not used. I tested it out using the minified version and everything works great, so here's a pull request! I assume this will help with loading times.

If there was a reason for avoiding the minified version, feel free to close this.