### PR TITLE
Add setup configuration so coldsweat can be installed as a Python package

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,5 @@
+graft coldsweat/templates
+
+graft static
+prune static/stylesheets
+include static/stylesheets/all.css

--- a/coldsweat/__init__.py
+++ b/coldsweat/__init__.py
@@ -36,13 +36,13 @@ USER_AGENT      = 'Coldsweat/%s Feed Fetcher <http://lab.passiomatic.com/coldswe
 #  to work for the fetcher script too
 installation_dir, _ = os.path.split(os.path.dirname(os.path.abspath(__file__))) 
 template_dir        = os.path.join(installation_dir, 'coldsweat/templates')
-plugin_dir          = os.path.join(installation_dir, 'plugins')
+plugin_dir          = os.path.abspath('plugins')
 
 # ------------------------------------------------------
 # Load up configuration settings
 # ------------------------------------------------------
 
-config = load_config(os.path.join(installation_dir, 'etc/config'))
+config = load_config(os.path.abspath('etc/config'))
 
 # ------------------------------------------------------
 # Configure logger

--- a/coldsweat/commands.py
+++ b/coldsweat/commands.py
@@ -98,7 +98,7 @@ class CommandController(FeedController, UserController):
     def command_serve(self, options, args):
         '''Starts a local server'''
     
-        static_app = DirectoryApp("static", index_page=None)
+        static_app = DirectoryApp(os.path.join(installation_dir, 'static'), index_page=None)
         
         # Create a cascade that looks for static files first, 
         #  then tries the other apps

--- a/setup.py
+++ b/setup.py
@@ -1,0 +1,19 @@
+from setuptools import setup
+
+setup(
+    name='coldsweat',
+    version='0.9.5',
+    packages=['coldsweat'],
+    install_requires=[
+        'Feedparser',
+        'Peewee',
+        'Requests',
+        'WebOb',
+        'Tempita',
+    ],
+    entry_points={
+        'console_scripts': ['sweat=coldsweat.commands:run'],
+    },
+    include_package_data=True,
+    zip_safe=False,
+)


### PR DESCRIPTION
With this change, all you have to do to run coldsweat is `pip install` the package, add a config file, and then you're set. No need to fork and clone this git repo :) Then, when it's time to update, it's just a matter of updating the package rather than having to merge upstream changes back into your branch.

I think this can make coldsweat easier to use and maintain, so I'm excited about it, but it is a fairly different strategy so there might be downsides to this I haven't considered. Let me know what concerns you have.

Testing done:
* verified that running from within the repo still works by fetching and serving
* verified that running as a package works by pip installing from my branch, setting up a new database, fetching it and serving