### PR TITLE
A ‘Fetch now’ URL feature added

### DIFF
--- a/coldsweat/config.py
+++ b/coldsweat/config.py
@@ -22,6 +22,7 @@ DEFAULTS = {
     'max_history'       : '7',
     'timeout'           : '10',
     'processes'         : '4',
+    'fetch_override'    : 'no',
     
     'level'             : 'INFO',
     'filename'          : '',       # Don't log
@@ -43,6 +44,7 @@ def load_config(config_path):
         'max_history'   : parser.getint,
         'timeout'       : parser.getint,
         'processes'     : parser.getint,
+        'fetch_override': parser.getboolean,
     }
 
     if os.path.exists(config_path):

--- a/coldsweat/frontend.py
+++ b/coldsweat/frontend.py
@@ -235,6 +235,15 @@ class FrontendApp(WSGIApp, FeedController, UserController):
         return self.respond_with_script('_modal_done.js', {'location': redirect_url})
                                 
     # Feeds
+    
+    @GET(r'^/feeds/fetch$')
+    def feed_fetch_all_now(self):
+    	if config.web.fetch_override:
+    		fc = FeedController()
+    		fc.fetch_all_feeds()
+    		return self.entry_list()
+    	else:
+    		raise HTTPForbidden('This feature has not been allowed')
 
     @GET(r'^/feeds/?$')
     @login_required    

--- a/etc/config-sample
+++ b/etc/config-sample
@@ -36,6 +36,9 @@ filename: coldsweat.log
 ; Static files served from a different server
 ;static_url: http://media.example.com/static
 
+; If enabled, all feeds will be re-fetched when 'http://<host>:<port>/feeds/fetch' is called, regardless of 'min_interval'. Response will be identical to the index page (and thus, account-protected).
+;fetch_override: no
+
 [plugins]
 
 ; Comma separated list of plugins to load


### PR DESCRIPTION
I have Coldsweat running on a NAS to synchronize several Fever-enabled client devices in local network. For some reason, I couldn't get it to automatically fetch all feeds in the configured time interval so I added a simple web-based (in practice browser-based) override. Also, it wasn't too comfortable for me to SSH into the machine to be able to force fetching all feeds at a certain time. This feature aims to offer an alternative and more user-friendly solution which you might be interested in integrating as well :).

My version is oblivious of user accounts (fetches all feeds) and login is not required before the operation is performed since I don't need that, but should you decide to integrate something like this, I think those properties shouldn't be absent. Behaviour and details should be apparent from the changes.